### PR TITLE
Introduce sequence numbers for bank statements and bump to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2025-05-06
+
+### Added
+- Support for sequence number tracking: now extracts both legal (`LglSeqNb`) and electronic (`ElctrncSeqNb`) sequence numbers for tracking statement chronology
+- Added `sequenceNumber` field to the `Camt053Statement` interface, which can come from either `LglSeqNb` or `ElctrncSeqNb`
+- New `samples` npm script for easier testing with sample files
+
+## [2.0.0] - 2025-04-12
+
+### Added
+- Initial public release
+- Support for multiple CAMT.053 versions: Out-of-the-box support for .001.02, .001.08, .001.13 (easily extendable)
+- XSD validation: Validates input XML against the appropriate XSD schema before parsing
+- Robust field extraction: Handles a wide variety of bank-specific layouts, including missing or non-standard fields
+- Batch and multi-transaction support: Correctly extracts all transactions, even when multiple `<TxDtls>` are present or missing
+- Graceful fallbacks: Provides sensible fallbacks for missing fields (e.g., uses Ntry-level info if TxDtls is missing)
+- Comprehensive output: Extracts account, balance, transaction, counterparty, remittance, and description fields
+- Sample files and schemas included: Test with real-world samples and official XSDs

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A robust Node.js/TypeScript parser for ISO 20022 CAMT.053 bank statement XML fil
 - **Batch and multi-transaction support**: Correctly extracts all transactions, even when multiple `<TxDtls>` are present or missing.
 - **Graceful fallbacks**: Provides sensible fallbacks for missing fields (e.g., uses Ntry-level info if TxDtls is missing).
 - **Comprehensive output**: Extracts account, balance, transaction, counterparty, remittance, and description fields.
+- **Statement sequence numbers**: Extracts both legal (`LglSeqNb`) and electronic (`ElctrncSeqNb`) sequence numbers for tracking statement chronology.
 - **Sample files and schemas included**: Test with real-world samples and official XSDs.
 
 ## Getting Started
@@ -62,6 +63,12 @@ A robust Node.js/TypeScript parser for ISO 20022 CAMT.053 bank statement XML fil
 Parse all XML files in the `samples/` directory and print the parsed output:
 
 ```sh
+npm run samples
+```
+
+Or build and run manually:
+
+```sh
 npm run build
 node dist/parse-samples.js
 ```
@@ -89,6 +96,7 @@ The parser returns an array of statements, each with:
 - `accountIBAN`
 - `currency`
 - `statementDate`
+- `sequenceNumber` — the sequence number of the statement, which can come from either `LglSeqNb` or `ElctrncSeqNb`
 - `openingBalance`
 - `closingBalance`
 - `numberOfCredits`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "iso20022-camt053-parser",
+  "name": "iso20022-camt-053-parser",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "iso20022-camt053-parser",
+      "name": "iso20022-camt-053-parser",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "iso20022-camt-053-parser",
-  "version": "0.1.0",
+  "version": "2.1.0",
   "description": "Robust ISO20022 CAMT.053 parser with XSD validation and JSON output",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "samples": "npm run build && node dist/parse-samples.js"
   },
   "keywords": [
     "iso20022",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -138,6 +138,9 @@ export async function parseCamt053(xml: string): Promise<Camt053Statement[]> {
     } else {
       currency = '';
     }
+    // Sequence Number (LglSeqNb or ElctrncSeqNb)
+    const sequenceNumberRaw = get(stmt, ['LglSeqNb']) ?? get(stmt, ['ElctrncSeqNb']);
+    const sequenceNumber = sequenceNumberRaw ? parseInt(sequenceNumberRaw, 10) : null;
     // Statement date
     let statementDate: string =
       extractDate(get(stmt, ['FrToDt', 'ToDtTm'])) // ISO standard: ToDtTm
@@ -347,6 +350,7 @@ export async function parseCamt053(xml: string): Promise<Camt053Statement[]> {
       accountIBAN,
       currency,
       statementDate,
+      sequenceNumber,
       openingBalance,
       closingBalance,
       numberOfCredits,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface Camt053Statement {
   accountIBAN: string | null;
   currency: string;
   statementDate: string; // ISO 8601 Date format (YYYY-MM-DD)
+  sequenceNumber: number | null; // Legal sequence number of the statement
   openingBalance: number | null;
   closingBalance: number | null;
   numberOfCredits: number | null;


### PR DESCRIPTION
### Added
- Support for sequence number tracking: now extracts both legal (`LglSeqNb`) and electronic (`ElctrncSeqNb`) sequence numbers for tracking statement chronology
- Added `sequenceNumber` field to the `Camt053Statement` interface, which can come from either `LglSeqNb` or `ElctrncSeqNb`
- New `samples` npm script for easier testing with sample files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added extraction and exposure of statement sequence numbers (from legal or electronic sources) in parsed CAMT.053 statements.
	- Introduced a new npm script to parse all sample files for easier testing.
- **Documentation**
	- Updated the README to describe sequence number extraction and new usage instructions.
	- Added a structured changelog documenting recent and past releases. 
- **Chores**
	- Updated package version to 2.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->